### PR TITLE
refactor(billing): read and write user data through the user contract

### DIFF
--- a/src/modules/billing/billing.module.spec.ts
+++ b/src/modules/billing/billing.module.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { StripeService } from 'src/external-service/stripe/stripe.service';
+import { USER_ACCOUNT } from 'src/modules/user/contracts/user-account.contract';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { BillingModule } from './billing.module';
 import {
@@ -16,7 +17,16 @@ describe('BillingModule', () => {
 
   const prismaMock = {
     payment: { create: jest.fn() },
-    user: { findUnique: jest.fn() },
+    user: { findUnique: jest.fn(), update: jest.fn() },
+  };
+
+  const stripeMock = { createCustomer: jest.fn() };
+
+  const userAccountMock = {
+    findUserByEmail: jest.fn(),
+    findBillingProfileById: jest.fn(),
+    findBillingProfileByStripeCustomerId: jest.fn(),
+    setStripeCustomerId: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -28,7 +38,9 @@ describe('BillingModule', () => {
       .overrideProvider(PrismaService)
       .useValue(prismaMock)
       .overrideProvider(StripeService)
-      .useValue({})
+      .useValue(stripeMock)
+      .overrideProvider(USER_ACCOUNT)
+      .useValue(userAccountMock)
       .compile();
   });
 
@@ -109,6 +121,63 @@ describe('BillingModule', () => {
         paymentType: 'RECURRING',
         description: undefined,
       },
+    });
+  });
+  describe('user data ownership', () => {
+    it('reads the stripe customer id through the user contract', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue({
+        id: 'user-1',
+        email: 'john.doe@example.com',
+        name: 'John Doe',
+        stripeCustomerId: 'cus_existing',
+      });
+
+      const service = moduleRef.get(BillingService);
+      await expect(service.getOrCreateStripeCustomer('user-1')).resolves.toBe(
+        'cus_existing',
+      );
+
+      expect(userAccountMock.findBillingProfileById).toHaveBeenCalledWith(
+        'user-1',
+      );
+      // Billing must not query the user table itself.
+      expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+      expect(stripeMock.createCustomer).not.toHaveBeenCalled();
+    });
+
+    it('writes a new stripe customer id through the user contract', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue({
+        id: 'user-1',
+        email: 'john.doe@example.com',
+        name: 'John Doe',
+        stripeCustomerId: null,
+      });
+      stripeMock.createCustomer.mockResolvedValue({ id: 'cus_new' });
+
+      const service = moduleRef.get(BillingService);
+      await expect(service.getOrCreateStripeCustomer('user-1')).resolves.toBe(
+        'cus_new',
+      );
+
+      expect(stripeMock.createCustomer).toHaveBeenCalledWith(
+        'john.doe@example.com',
+        'John Doe',
+      );
+      expect(userAccountMock.setStripeCustomerId).toHaveBeenCalledWith(
+        'user-1',
+        'cus_new',
+      );
+      // The user table write goes through the contract, not Prisma.
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
+    });
+
+    it('throws when the user contract knows no such user', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue(null);
+
+      const service = moduleRef.get(BillingService);
+      await expect(
+        service.getOrCreateStripeCustomer('missing'),
+      ).rejects.toThrow('User with id missing not found');
     });
   });
 });

--- a/src/modules/billing/billing.module.ts
+++ b/src/modules/billing/billing.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ExternalServiceModule } from 'src/external-service/external-service.module';
+import { UserModule } from 'src/modules/user/user.module';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { PAYMENT_RECORDER } from './contracts/payment-recorder.contract';
 import { BillingController } from './controllers/billing.controller';
@@ -7,7 +8,9 @@ import { BillingRepository } from './repositories/billing.repository';
 import { BillingService } from './services/billing.service';
 
 @Module({
-  imports: [PrismaModule, ExternalServiceModule],
+  // UserModule supplies USER_ACCOUNT, through which billing reads and writes
+  // user data instead of touching the user table itself.
+  imports: [PrismaModule, ExternalServiceModule, UserModule],
   controllers: [BillingController],
   providers: [
     BillingService,

--- a/src/modules/billing/contracts/payment-recorder.contract.ts
+++ b/src/modules/billing/contracts/payment-recorder.contract.ts
@@ -1,4 +1,5 @@
-import type { Payment, PaymentType, User } from '@prisma/client';
+import type { Payment, PaymentType } from '@prisma/client';
+import type { UserBillingProfile } from 'src/modules/user/contracts/user-account.contract';
 
 /**
  * Public contract of the billing module.
@@ -35,8 +36,10 @@ export interface PaymentRecorderContract {
   /**
    * Resolve the account behind a Stripe customer id.
    *
-   * This reads the user table, which the billing module does not own. See the
-   * ownership note in BillingRepository.
+   * Billing does not own the user table, so this is served through the user
+   * module's contract.
    */
-  findUserByStripeCustomerId(stripeCustomerId: string): Promise<User | null>;
+  findUserByStripeCustomerId(
+    stripeCustomerId: string,
+  ): Promise<UserBillingProfile | null>;
 }

--- a/src/modules/billing/repositories/billing.repository.ts
+++ b/src/modules/billing/repositories/billing.repository.ts
@@ -57,32 +57,4 @@ export class BillingRepository {
       },
     });
   }
-
-  // Ownership note: billing owns the payment table. The three methods below
-  // read and write the user table, which the user module owns, so they breach
-  // the module boundary. They are left in place here to keep this commit a
-  // behaviour-preserving move; fixing them means either widening the user
-  // module's public contract or giving billing its own customer mapping table,
-  // which is a schema migration.
-  async findUserById(userId: string) {
-    return this.prismaService.user.findUnique({
-      where: { id: userId },
-    });
-  }
-
-  async updateUserStripeCustomerId(
-    userId: string,
-    stripeCustomerId: string,
-  ): Promise<void> {
-    await this.prismaService.user.update({
-      where: { id: userId },
-      data: { stripeCustomerId },
-    });
-  }
-
-  async findUserByStripeCustomerId(stripeCustomerId: string) {
-    return this.prismaService.user.findUnique({
-      where: { stripeCustomerId },
-    });
-  }
 }

--- a/src/modules/billing/services/billing.service.ts
+++ b/src/modules/billing/services/billing.service.ts
@@ -1,6 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import type { Payment, PaymentType } from '@prisma/client';
 import type { PaymentRecorderContract } from '../contracts/payment-recorder.contract';
+import { USER_ACCOUNT } from 'src/modules/user/contracts/user-account.contract';
+import type {
+  UserAccountContract,
+  UserBillingProfile,
+} from 'src/modules/user/contracts/user-account.contract';
 import { BillingRepository } from '../repositories/billing.repository';
 import { StripeService } from 'src/external-service/stripe/stripe.service';
 import { CreatePaymentIntentDto } from '../dtos/create-payment-intent.dto';
@@ -37,10 +42,12 @@ export class BillingService implements PaymentRecorderContract {
   constructor(
     private readonly billingRepository: BillingRepository,
     private readonly stripeService: StripeService,
+    @Inject(USER_ACCOUNT)
+    private readonly userAccount: UserAccountContract,
   ) {}
 
   async getOrCreateStripeCustomer(userId: string): Promise<string> {
-    const user = await this.billingRepository.findUserById(userId);
+    const user = await this.userAccount.findBillingProfileById(userId);
 
     if (!user) {
       throw new NotFoundException(`User with id ${userId} not found`);
@@ -58,10 +65,7 @@ export class BillingService implements PaymentRecorderContract {
     );
 
     // Save Stripe customer ID to user
-    await this.billingRepository.updateUserStripeCustomerId(
-      userId,
-      stripeCustomer.id,
-    );
+    await this.userAccount.setStripeCustomerId(userId, stripeCustomer.id);
 
     return stripeCustomer.id;
   }
@@ -204,8 +208,12 @@ export class BillingService implements PaymentRecorderContract {
     });
   }
 
-  async findUserByStripeCustomerId(stripeCustomerId: string) {
-    return this.billingRepository.findUserByStripeCustomerId(stripeCustomerId);
+  async findUserByStripeCustomerId(
+    stripeCustomerId: string,
+  ): Promise<UserBillingProfile | null> {
+    return this.userAccount.findBillingProfileByStripeCustomerId(
+      stripeCustomerId,
+    );
   }
 
   async createSetupIntent(userId: string): Promise<{ clientSecret: string }> {

--- a/src/modules/user/contracts/user-account.contract.ts
+++ b/src/modules/user/contracts/user-account.contract.ts
@@ -9,6 +9,20 @@ import { UserDto } from '../dtos/user.dto';
  */
 export const USER_ACCOUNT = Symbol('USER_ACCOUNT');
 
+/**
+ * The slice of a user that the billing module needs.
+ *
+ * The user module owns the user table, so billing reaches this data through
+ * the contract instead of querying or updating that table itself. Only the
+ * fields billing actually consumes are exposed.
+ */
+export interface UserBillingProfile {
+  id: string;
+  email: string;
+  name: string;
+  stripeCustomerId: string | null;
+}
+
 export interface UserAccountContract {
   /**
    * Look a user up by email.
@@ -21,4 +35,20 @@ export interface UserAccountContract {
     email: string,
     includePasswordField?: boolean,
   ): Promise<UserDto>;
+
+  /**
+   * Billing profile for a user id, or null when no such user exists.
+   *
+   * Unlike findUserById this does not filter out soft-deleted users, because
+   * payment events can arrive for an account after it has been deactivated.
+   */
+  findBillingProfileById(userId: string): Promise<UserBillingProfile | null>;
+
+  /** Billing profile behind a Stripe customer id, or null when unmapped. */
+  findBillingProfileByStripeCustomerId(
+    stripeCustomerId: string,
+  ): Promise<UserBillingProfile | null>;
+
+  /** Attach a Stripe customer id to a user. */
+  setStripeCustomerId(userId: string, stripeCustomerId: string): Promise<void>;
 }

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -188,6 +188,32 @@ export class UserRepository {
     });
   }
 
+  // Billing-facing accessors. These intentionally do not apply the
+  // deletedAt filter or the role include used elsewhere in this repository,
+  // because they replace queries the billing module previously ran against
+  // the user table directly and must behave identically.
+  async findBillingProfileById(userId: string) {
+    return this.prismaService.user.findUnique({
+      where: { id: userId },
+    });
+  }
+
+  async findBillingProfileByStripeCustomerId(stripeCustomerId: string) {
+    return this.prismaService.user.findUnique({
+      where: { stripeCustomerId },
+    });
+  }
+
+  async setStripeCustomerId(
+    userId: string,
+    stripeCustomerId: string,
+  ): Promise<void> {
+    await this.prismaService.user.update({
+      where: { id: userId },
+      data: { stripeCustomerId },
+    });
+  }
+
   async findSoftDeletedUsersByIds(
     ids: string[],
   ): Promise<UserWithRoleAndPermission[]> {

--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -4,7 +4,10 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { UserAccountContract } from '../contracts/user-account.contract';
+import type {
+  UserAccountContract,
+  UserBillingProfile,
+} from '../contracts/user-account.contract';
 import { UserRepository } from '../repositories/user.repository';
 import { UserDto } from '../dtos/user.dto';
 import { plainToInstance } from 'class-transformer';
@@ -203,4 +206,42 @@ export class UserService implements UserAccountContract {
     await this.userRepository.bulkRestoreUsers(payload.ids);
     return { success: true, message: 'Users bulk restored successfully' };
   }
+
+  async findBillingProfileById(
+    userId: string,
+  ): Promise<UserBillingProfile | null> {
+    const user = await this.userRepository.findBillingProfileById(userId);
+    return user && toBillingProfile(user);
+  }
+
+  async findBillingProfileByStripeCustomerId(
+    stripeCustomerId: string,
+  ): Promise<UserBillingProfile | null> {
+    const user =
+      await this.userRepository.findBillingProfileByStripeCustomerId(
+        stripeCustomerId,
+      );
+    return user && toBillingProfile(user);
+  }
+
+  async setStripeCustomerId(
+    userId: string,
+    stripeCustomerId: string,
+  ): Promise<void> {
+    await this.userRepository.setStripeCustomerId(userId, stripeCustomerId);
+  }
+}
+
+function toBillingProfile(user: {
+  id: string;
+  email: string;
+  name: string;
+  stripeCustomerId: string | null;
+}): UserBillingProfile {
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    stripeCustomerId: user.stripeCustomerId,
+  };
 }

--- a/src/modules/user/user.module.spec.ts
+++ b/src/modules/user/user.module.spec.ts
@@ -15,6 +15,7 @@ describe('UserModule', () => {
   const prismaMock = {
     user: {
       findUnique: jest.fn(),
+      update: jest.fn(),
     },
   };
 
@@ -87,5 +88,73 @@ describe('UserModule', () => {
     // UserDto declares password with @Exclude(), so the key survives
     // plainToInstance but the hash is dropped.
     expect(result.password).toBeUndefined();
+  });
+  describe('billing profile access', () => {
+    const record = {
+      id: 'user-1',
+      email: 'john.doe@example.com',
+      name: 'John Doe',
+      password: 'hashed',
+      stripeCustomerId: 'cus_123',
+    };
+
+    it('exposes only the billing fields, never the password', async () => {
+      prismaMock.user.findUnique.mockResolvedValue(record);
+
+      const account = moduleRef.get<UserAccountContract>(USER_ACCOUNT);
+      const profile = await account.findBillingProfileById('user-1');
+
+      expect(profile).toEqual({
+        id: 'user-1',
+        email: 'john.doe@example.com',
+        name: 'John Doe',
+        stripeCustomerId: 'cus_123',
+      });
+    });
+
+    it('does not filter out soft-deleted users', async () => {
+      prismaMock.user.findUnique.mockResolvedValue(record);
+
+      const account = moduleRef.get<UserAccountContract>(USER_ACCOUNT);
+      await account.findBillingProfileById('user-1');
+
+      // Payment events can arrive after deactivation, so this lookup must
+      // match the query billing previously ran: no deletedAt filter.
+      expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+      });
+    });
+
+    it('resolves a profile from a stripe customer id', async () => {
+      prismaMock.user.findUnique.mockResolvedValue(record);
+
+      const account = moduleRef.get<UserAccountContract>(USER_ACCOUNT);
+      const profile =
+        await account.findBillingProfileByStripeCustomerId('cus_123');
+
+      expect(profile?.id).toBe('user-1');
+      expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+        where: { stripeCustomerId: 'cus_123' },
+      });
+    });
+
+    it('returns null when no user matches', async () => {
+      prismaMock.user.findUnique.mockResolvedValue(null);
+
+      const account = moduleRef.get<UserAccountContract>(USER_ACCOUNT);
+      await expect(
+        account.findBillingProfileById('missing'),
+      ).resolves.toBeNull();
+    });
+
+    it('writes the stripe customer id', async () => {
+      const account = moduleRef.get<UserAccountContract>(USER_ACCOUNT);
+      await account.setStripeCustomerId('user-1', 'cus_new');
+
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { stripeCustomerId: 'cus_new' },
+      });
+    });
   });
 });


### PR DESCRIPTION
Billing owns the payment table but was querying and updating the user table, which the user module owns, including a write in BillingRepository.updateUserStripeCustomerId. That is the table ownership breach flagged when billing was moved.

Widen the user module's public contract with a UserBillingProfile view and three methods: findBillingProfileById,
findBillingProfileByStripeCustomerId and setStripeCustomerId. The profile exposes only id, email, name and stripeCustomerId, so the password hash and the rest of the user record stay inside the user module.

BillingService now injects USER_ACCOUNT for that data and BillingRepository drops its three user-table methods, so billing only touches the payment table.

The new user repository methods deliberately skip the deletedAt filter and the role include used elsewhere in that repository. They replace queries billing ran directly, and payment events can arrive for an account after it has been deactivated, so filtering would change behavior.

PaymentRecorderContract.findUserByStripeCustomerId now returns a UserBillingProfile instead of a Prisma User. The Stripe webhook only reads id from it, so the narrower type is a drop-in change.

This is option A of the two fixes noted when billing was moved. Option B, giving billing its own customer mapping table, remains possible later and is now a smaller change because the access is behind a contract.

Behavior is unchanged: the same Stripe customer is resolved or created, and the same column is written.