### PR TITLE
refactor(role): publish role types through a public contract

### DIFF
--- a/src/modules/auth/dtos/login-response.dto.ts
+++ b/src/modules/auth/dtos/login-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { RoleDto } from 'src/modules/role/dtos/role.dto';
+import { RoleDto } from 'src/modules/role/contracts/role.contract';
 import { UserDto } from 'src/modules/user/dtos/user.dto';
 
 export class LoginResponseDto {

--- a/src/modules/role/contracts/role.contract.spec.ts
+++ b/src/modules/role/contracts/role.contract.spec.ts
@@ -1,0 +1,50 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { PermissionDto, RoleDto } from './role.contract';
+
+const SRC_DIR = join(__dirname, '..', '..', '..');
+const ROLE_DIR = join(SRC_DIR, 'modules', 'role');
+
+function typescriptFilesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return typescriptFilesUnder(full);
+    return entry.isFile() && full.endsWith('.ts') ? [full] : [];
+  });
+}
+
+describe('role public contract', () => {
+  it('re-exports the shapes other modules embed', () => {
+    expect(RoleDto).toBeDefined();
+    expect(PermissionDto).toBeDefined();
+  });
+
+  it('is the only role path other modules import from', () => {
+    // Any import of src/modules/role/... that is not the contract is a reach
+    // into role's internals. Keeping this mechanical means the boundary holds
+    // as new modules are added, rather than relying on reviewer memory.
+    const offenders: string[] = [];
+
+    for (const file of typescriptFilesUnder(SRC_DIR)) {
+      if (file.startsWith(ROLE_DIR + sep)) continue;
+
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, index) => {
+          // Absolute (src/modules/role/x) and relative (../../role/x) forms.
+          const match =
+            /['"](?:src\/modules\/|(?:\.\.\/)+)role\/([^'"]+)['"]/.exec(line);
+          // role.module is the class the composition root wires up; the
+          // contract is the published surface. Anything else is internal.
+          const allowed = ['contracts/role.contract', 'role.module'];
+          if (match && !allowed.includes(match[1])) {
+            offenders.push(
+              `${relative(SRC_DIR, file)}:${index + 1} -> ${match[1]}`,
+            );
+          }
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/modules/role/contracts/role.contract.ts
+++ b/src/modules/role/contracts/role.contract.ts
@@ -1,0 +1,13 @@
+/**
+ * Public contract of the role module.
+ *
+ * Modules that embed a role in their own responses, such as user and auth,
+ * import these shapes from here. Everything else under role/ is internal and
+ * must not be imported from outside the module; role.contract.spec.ts enforces
+ * that.
+ *
+ * Unlike USER_ACCOUNT and PAYMENT_RECORDER this contract carries no injection
+ * token. Nothing outside the role module calls role behaviour, only describes
+ * role data, so there is no provider to expose.
+ */
+export { PermissionDto, RoleDto } from '../dtos/role.dto';

--- a/src/modules/user/dtos/user.dto.ts
+++ b/src/modules/user/dtos/user.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { type AccountStatus, accountStatus } from '../enums/enum';
 import { Exclude, Expose } from 'class-transformer';
-import { RoleDto } from 'src/modules/role/dtos/role.dto';
+import { RoleDto } from 'src/modules/role/contracts/role.contract';
 export class UserDto {
   @ApiProperty({
     format: 'uuid',


### PR DESCRIPTION
The user and auth DTOs imported RoleDto from src/modules/role/dtos/, reaching directly into another module's internals. That was the last cross-module coupling left after the module moves.

Add role/contracts/role.contract.ts as the role module's published surface and point both consumers at it. Unlike USER_ACCOUNT and PAYMENT_RECORDER this contract carries no injection token: nothing outside role calls role behaviour, it only describes role data, so there is no provider to expose and RoleModule still exports nothing.

RoleDto keeps its identity, so the generated OpenAPI schema is unchanged and no client is affected. Serialization is untouched too: UserDto.role has no @Type, so class-transformer already passed the value through as-is.

A contract that is only a naming convention decays, so role.contract.spec.ts scans src/ and fails on any import of src/modules/role/... or ../role/... that is not the contract itself or role.module, which the composition root needs. Both the absolute and the relative evasion forms were confirmed to fail the test before this was committed.