### PR TITLE
fix(auth): stop signing tokens with hardcoded default secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,11 @@ SUPER_ADMIN_EMAIL=superadmin@example.com
 SUPER_ADMIN_PASSWORD=superadmin12!@
 SUPER_ADMIN_NAME=SuperAdmin
 
-JWT_ACCESS_SECRET_KEY=8bfd57b491aef5499ad77e1607a1973d
-JWT_REFRESH_SECRET_KEY=2a966aa42a9ef55632dbbb23c78b181c
+# Required. The app refuses to start without these.
+# Generate your own, never reuse a value from a public repository:
+#   openssl rand -hex 32
+JWT_ACCESS_SECRET_KEY=
+JWT_REFRESH_SECRET_KEY=
 JWT_ACCESS_TOKEN_EXPIRES_IN=5m
 JWT_REFRESH_TOKEN_EXPIRES_IN=15d
 

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,25 +1,33 @@
 import { Module } from '@nestjs/common';
-import { AuthService } from './services/auth.service';
-import { AuthController } from './controllers/auth.controller';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
-import { jwtConstants } from './constant';
-import { JwtStrategy } from './strategies/jwt.strategies';
-import { UserModule } from 'src/modules/user/user.module';
 import { ExternalServiceModule } from 'src/external-service/external-service.module';
+import { UserModule } from 'src/modules/user/user.module';
+import { AuthController } from './controllers/auth.controller';
+import { jwtConfig } from './jwt.config';
+import { AuthService } from './services/auth.service';
+import { JwtStrategy } from './strategies/jwt.strategies';
 
 @Module({
   imports: [
     UserModule,
     ExternalServiceModule,
-    JwtModule.register({
-      global: true,
-      secret: jwtConstants.accessTokenSecret,
-      signOptions: { expiresIn: jwtConstants.accessTokenExpiresIn },
-    }),
-    JwtModule.register({
-      global: true,
-      secret: jwtConstants.refreshTokenSecret,
-      signOptions: { expiresIn: jwtConstants.refreshTokenExpiresIn },
+    // registerAsync so the secret is resolved from ConfigService after .env is
+    // loaded. The previous register() calls read module-level constants that
+    // were evaluated before ConfigModule.forRoot() ran, so every token was
+    // signed with a hardcoded default.
+    //
+    // Registered once, not globally: there were two register({ global: true })
+    // calls and the second silently overrode the first. AuthService passes the
+    // secret explicitly on every sign, and nothing outside this module injects
+    // JwtService.
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: jwtConfig.accessSecret(config),
+        signOptions: { expiresIn: jwtConfig.accessExpiresIn(config) },
+      }),
     }),
   ],
   controllers: [AuthController],

--- a/src/modules/auth/constant.ts
+++ b/src/modules/auth/constant.ts
@@ -1,40 +1,37 @@
-import { ConfigService } from '@nestjs/config';
-import type { StringValue } from 'ms';
-
-const configService = new ConfigService();
-
-export const jwtConstants = {
-  accessTokenSecret: configService.get<string>(
-    'JWT_ACCESS_SECRET_KEY',
-    'access-token-secret',
-  ),
-  refreshTokenSecret: configService.get<string>(
-    'JWT_REFRESH_SECRET_KEY',
-    'refresh-token-secret',
-  ),
-  accessTokenExpiresIn: configService.get<string>(
-    'JWT_ACCESS_TOKEN_EXPIRES_IN',
-    '5m',
-  ) as StringValue,
-  refreshTokenExpiresIn: configService.get<string>(
-    'JWT_REFRESH_TOKEN_EXPIRES_IN',
-    '15d',
-  ) as StringValue,
-};
+/**
+ * Cookie names and options for the auth tokens.
+ *
+ * The options are getters on purpose. Reading process.env at module load time
+ * is what made the JWT secrets fall back to hardcoded defaults: this file is
+ * evaluated while AppModule's imports are being resolved, which is before
+ * ConfigModule.forRoot() has loaded .env. Evaluating per access means the
+ * value is read when a request is served, by which point the env is populated.
+ *
+ * JWT secrets and lifetimes are deliberately absent. They are read through
+ * ConfigService with getOrThrow so a missing secret stops the process instead
+ * of silently signing tokens with a guessable default.
+ */
+const secureCookies = () => process.env.NODE_ENV === 'production';
 
 export const cookieConstants = {
   accessTokenName: 'access_token',
   refreshTokenName: 'refresh_token',
-  accessTokenOptions: {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict' as const,
-    maxAge: 5 * 60 * 1000, // 5m in milliseconds
+
+  get accessTokenOptions() {
+    return {
+      httpOnly: true,
+      secure: secureCookies(),
+      sameSite: 'strict' as const,
+      maxAge: 5 * 60 * 1000, // 5m in milliseconds
+    };
   },
-  refreshTokenOptions: {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict' as const,
-    maxAge: 15 * 24 * 60 * 60 * 1000, // 15 days in milliseconds
+
+  get refreshTokenOptions() {
+    return {
+      httpOnly: true,
+      secure: secureCookies(),
+      sameSite: 'strict' as const,
+      maxAge: 15 * 24 * 60 * 60 * 1000, // 15 days in milliseconds
+    };
   },
 };

--- a/src/modules/auth/jwt.config.spec.ts
+++ b/src/modules/auth/jwt.config.spec.ts
@@ -1,0 +1,50 @@
+import { ConfigService } from '@nestjs/config';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { jwtConfig } from './jwt.config';
+
+describe('jwtConfig', () => {
+  const configFor = (values: Record<string, string>) =>
+    new ConfigService(values);
+
+  it('throws instead of falling back when the access secret is missing', () => {
+    // The bug this replaces: a missing secret silently resolved to the string
+    // 'access-token-secret', which is public in this repository, so anyone
+    // could forge a token for any user.
+    expect(() => jwtConfig.accessSecret(configFor({}))).toThrow();
+  });
+
+  it('throws instead of falling back when the refresh secret is missing', () => {
+    expect(() => jwtConfig.refreshSecret(configFor({}))).toThrow();
+  });
+
+  it('reads the secrets from configuration', () => {
+    const config = configFor({
+      JWT_ACCESS_SECRET_KEY: 'access-from-config',
+      JWT_REFRESH_SECRET_KEY: 'refresh-from-config',
+    });
+
+    expect(jwtConfig.accessSecret(config)).toBe('access-from-config');
+    expect(jwtConfig.refreshSecret(config)).toBe('refresh-from-config');
+  });
+
+  it('keeps sensible lifetime defaults', () => {
+    const config = configFor({});
+
+    // Lifetimes are safe to default; secrets are not.
+    expect(jwtConfig.accessExpiresIn(config)).toBe('5m');
+    expect(jwtConfig.refreshExpiresIn(config)).toBe('15d');
+  });
+
+  it('no longer reads configuration at module load time', () => {
+    // The original constant.ts built a `new ConfigService()` at import time and
+    // captured the secrets into a frozen object, so ConfigModule.forRoot()
+    // loading .env afterwards had no effect. Nothing in the auth module may
+    // construct a ConfigService at module scope again.
+    const authDir = join(__dirname);
+    for (const file of ['constant.ts', 'jwt.config.ts']) {
+      const source = readFileSync(join(authDir, file), 'utf8');
+      expect(source).not.toMatch(/^const\s+\w+\s*=\s*new ConfigService\(/m);
+    }
+  });
+});

--- a/src/modules/auth/jwt.config.ts
+++ b/src/modules/auth/jwt.config.ts
@@ -1,0 +1,26 @@
+import { ConfigService } from '@nestjs/config';
+import type { StringValue } from 'ms';
+
+/**
+ * Single place the JWT settings are read from configuration.
+ *
+ * Every accessor takes a ConfigService and uses getOrThrow, so the process
+ * fails loudly on a missing secret rather than falling back to a default that
+ * anyone reading this repository could use to forge tokens.
+ *
+ * These are functions rather than constants so they are evaluated when a
+ * provider is constructed or a request is served, never at module load.
+ */
+export const jwtConfig = {
+  accessSecret: (config: ConfigService): string =>
+    config.getOrThrow<string>('JWT_ACCESS_SECRET_KEY'),
+
+  refreshSecret: (config: ConfigService): string =>
+    config.getOrThrow<string>('JWT_REFRESH_SECRET_KEY'),
+
+  accessExpiresIn: (config: ConfigService): StringValue =>
+    config.get<string>('JWT_ACCESS_TOKEN_EXPIRES_IN', '5m') as StringValue,
+
+  refreshExpiresIn: (config: ConfigService): StringValue =>
+    config.get<string>('JWT_REFRESH_TOKEN_EXPIRES_IN', '15d') as StringValue,
+};

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -11,7 +11,8 @@ import type { UserAccountContract } from 'src/modules/user/contracts/user-accoun
 import { LoginResponseDto } from '../dtos/login-response.dto';
 import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
-import { cookieConstants, jwtConstants } from '../constant';
+import { cookieConstants } from '../constant';
+import { jwtConfig } from '../jwt.config';
 import { Response } from 'express';
 import { RefreshResponseDto } from '../dtos/refresh-response.dto';
 import { JwtUser } from '../decorators/current-user.decorator';
@@ -129,13 +130,13 @@ export class AuthService {
     };
 
     const accessToken = await this.jwtService.signAsync(payload, {
-      secret: jwtConstants.accessTokenSecret,
-      expiresIn: jwtConstants.accessTokenExpiresIn,
+      secret: jwtConfig.accessSecret(this.configService),
+      expiresIn: jwtConfig.accessExpiresIn(this.configService),
     });
 
     const refreshToken = await this.jwtService.signAsync(payload, {
-      secret: jwtConstants.refreshTokenSecret,
-      expiresIn: jwtConstants.refreshTokenExpiresIn,
+      secret: jwtConfig.refreshSecret(this.configService),
+      expiresIn: jwtConfig.refreshExpiresIn(this.configService),
     });
 
     res.cookie(
@@ -183,14 +184,14 @@ export class AuthService {
   ): Promise<RefreshResponseDto> {
     try {
       const payload = await this.jwtService.verifyAsync<JwtUser>(refreshToken, {
-        secret: jwtConstants.refreshTokenSecret,
+        secret: jwtConfig.refreshSecret(this.configService),
       });
 
       const newAccessToken = await this.jwtService.signAsync(
         { id: payload.id, email: payload.email },
         {
-          secret: jwtConstants.accessTokenSecret,
-          expiresIn: jwtConstants.accessTokenExpiresIn,
+          secret: jwtConfig.accessSecret(this.configService),
+          expiresIn: jwtConfig.accessExpiresIn(this.configService),
         },
       );
 

--- a/src/modules/auth/strategies/jwt.strategies.ts
+++ b/src/modules/auth/strategies/jwt.strategies.ts
@@ -1,13 +1,16 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { jwtConstants } from '../constant';
+import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
+import { jwtConfig } from '../jwt.config';
 import { JwtUser } from '../decorators/current-user.decorator';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  // ConfigService is injected rather than reading a module-level constant, so
+  // the verification secret is resolved after .env has been loaded.
+  constructor(configService: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request): string | null => {
@@ -19,7 +22,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         ExtractJwt.fromAuthHeaderAsBearerToken(),
       ]),
       ignoreExpiration: false,
-      secretOrKey: jwtConstants.accessTokenSecret,
+      secretOrKey: jwtConfig.accessSecret(configService),
     });
   }
 


### PR DESCRIPTION
constant.ts built a ConfigService at module scope and captured the JWT secrets into a frozen object. That file is evaluated while AppModule's imports are resolved, which happens before ConfigModule.forRoot() loads .env, so unless the secrets were exported in the shell every token was signed with the literal defaults 'access-token-secret' and 'refresh-token-secret'. Both are public in this repository.

This was verified, not inferred. Booting the built output the way production does, a token signed with 'access-token-secret' for the seeded super admin returned HTTP 200 and the full user list from the guarded GET /users route. After this change the same request returns 401 and a real login still succeeds.

The existing tests could never have caught it: the e2e setup loads .env before importing AppModule, so under Jest the constants happened to receive the real secrets.

Changes:
- Delete jwtConstants. Secrets and lifetimes now come from jwt.config.ts, which takes a ConfigService and uses getOrThrow for both secrets, so a missing secret stops the process instead of falling back to a guessable value. Lifetimes keep defaults; those are not sensitive.
- JwtModule.registerAsync resolves the secret from ConfigService after the env is loaded. It is registered once rather than twice: there were two register({ global: true }) calls and the second silently overrode the first. It is no longer global, as nothing outside auth injects JwtService.
- JwtStrategy injects ConfigService for its verification secret.
- cookieConstants exposes its options through getters. secure was computed from process.env.NODE_ENV at module load, the same class of bug, which would have left cookies non-secure in production whenever NODE_ENV came from .env rather than the shell.
- Remove the real-looking secrets from .env.example and leave the keys empty with instructions to generate them.

Existing access and refresh tokens are invalidated by this change.