### PR TITLE
test(e2e): make the e2e suite runnable and cover the authorization path

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand --forceExit",
     "prepare": "husky"
   },
   "dependencies": {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,25 +1,30 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import type { App } from 'supertest/types';
+import request from 'supertest';
+import { createTestApp } from './create-test-app';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    await app.init();
+  // Booting the real AppModule is the point of this suite: it resolves the
+  // whole dependency graph against a live Postgres and Redis, which the unit
+  // specs cannot do.
+  beforeAll(async () => {
+    ({ app } = await createTestApp());
   });
 
-  it('/ (GET)', () => {
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('serves the health check under the global prefix', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/api/v1/health')
       .expect(200)
-      .expect('Hello World!');
+      .expect('Our aerovex backend is running');
+  });
+
+  it('does not serve routes without the prefix', () => {
+    return request(app.getHttpServer()).get('/health').expect(404);
   });
 });

--- a/test/auth-permissions.e2e-spec.ts
+++ b/test/auth-permissions.e2e-spec.ts
@@ -1,0 +1,151 @@
+import { INestApplication } from '@nestjs/common';
+import type { App } from 'supertest/types';
+import request from 'supertest';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { createTestApp } from './create-test-app';
+
+/**
+ * End-to-end coverage of the authorization path.
+ *
+ * PermissionsGuard now reads permissions through the user module's
+ * USER_ACCOUNT contract rather than through PrismaService. The unit tests
+ * cover its branches with mocks; this suite is the only place the guard runs
+ * against a real request, a real JWT and a real database.
+ */
+describe('Authentication and permissions (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+
+  const superAdminEmail = process.env.SUPER_ADMIN_EMAIL as string;
+  const superAdminPassword = process.env.SUPER_ADMIN_PASSWORD as string;
+
+  const limitedRoleName = 'e2e-no-permissions';
+  const limitedEmail = 'e2e-no-permissions@example.com';
+  const limitedPassword = 'e2e-password-123';
+
+  let superAdminCookies: string[];
+  let limitedCookies: string[];
+
+  const login = async (email: string, password: string) => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/login')
+      .send({ email, password });
+    return response;
+  };
+
+  const cookiesOf = (response: request.Response): string[] => {
+    const raw = response.headers['set-cookie'];
+    return Array.isArray(raw) ? raw : [raw].filter(Boolean);
+  };
+
+  // Permissions hold a foreign key to their role, so they have to go first.
+  // Doing this defensively rather than assuming the role has none keeps the
+  // suite repeatable even if a previous run died midway.
+  const removeFixtures = async () => {
+    await prisma.user.deleteMany({ where: { email: limitedEmail } });
+    const roles = await prisma.role.findMany({
+      where: { name: limitedRoleName },
+      select: { id: true },
+    });
+    if (roles.length > 0) {
+      await prisma.permission.deleteMany({
+        where: { roleId: { in: roles.map((role) => role.id) } },
+      });
+      await prisma.role.deleteMany({ where: { name: limitedRoleName } });
+    }
+  };
+
+  beforeAll(async () => {
+    ({ app } = await createTestApp());
+    prisma = app.get(PrismaService);
+
+    expect(superAdminEmail).toBeTruthy();
+    expect(superAdminPassword).toBeTruthy();
+
+    // Remove leftovers from a previous run so the suite is repeatable.
+    await removeFixtures();
+
+    const superAdminLogin = await login(superAdminEmail, superAdminPassword);
+    expect(superAdminLogin.status).toBe(201);
+    superAdminCookies = cookiesOf(superAdminLogin);
+
+    // A role with no permissions at all, created through the real API.
+    const role = await prisma.role.create({
+      data: { name: limitedRoleName },
+    });
+
+    await request(app.getHttpServer())
+      .post('/api/v1/users')
+      .set('Cookie', superAdminCookies)
+      .send({
+        name: 'E2E No Permissions',
+        email: limitedEmail,
+        password: limitedPassword,
+        accountStatus: 'ACTIVE',
+        isActive: true,
+        roleId: role.id,
+      })
+      .expect(201);
+
+    const limitedLogin = await login(limitedEmail, limitedPassword);
+    expect(limitedLogin.status).toBe(201);
+    limitedCookies = cookiesOf(limitedLogin);
+  });
+
+  afterAll(async () => {
+    if (prisma) {
+      await removeFixtures();
+    }
+    await app?.close();
+  });
+
+  describe('login', () => {
+    it('sets httpOnly access and refresh cookies', () => {
+      expect(superAdminCookies.join(';')).toContain('access_token=');
+      expect(superAdminCookies.join(';')).toContain('refresh_token=');
+      expect(superAdminCookies.join(';')).toContain('HttpOnly');
+    });
+
+    it('rejects a wrong password', async () => {
+      // Deliberately a throwaway account: failed attempts are tracked in Redis
+      // and would lock the super admin for later tests.
+      const response = await login(limitedEmail, 'definitely-not-the-password');
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('PermissionsGuard against a real request', () => {
+    it('rejects an unauthenticated request to a guarded route', () => {
+      return request(app.getHttpServer()).get('/api/v1/users').expect(401);
+    });
+
+    it('allows a user whose role grants the required permission', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/users')
+        .set('Cookie', superAdminCookies);
+
+      expect(response.status).toBe(200);
+    });
+
+    it('rejects a user whose role grants no permissions', async () => {
+      // The path that regressed most easily in the refactor: the guard has to
+      // resolve permissions through USER_ACCOUNT and deny on an empty list,
+      // rather than erroring or defaulting to allow.
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/users')
+        .set('Cookie', limitedCookies);
+
+      expect(response.status).toBe(401);
+    });
+
+    it('allows a route guarded by authentication only', async () => {
+      // /users/me uses JwtAuthGuard without PermissionsGuard, so the
+      // permission-less user must still get through.
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/users/me')
+        .set('Cookie', limitedCookies);
+
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/test/create-test-app.ts
+++ b/test/create-test-app.ts
@@ -1,0 +1,44 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { App } from 'supertest/types';
+import cookieParser from 'cookie-parser';
+import { AllExceptionsFilter } from '../src/common/filters/all-exceptions.filter';
+import { AppModule } from '../src/app.module';
+
+/**
+ * Boots the real AppModule with the same middleware main.ts applies.
+ *
+ * Without this the test app would differ from production in ways that hide
+ * bugs: no global api/v1 prefix, no cookie parsing (so the JWT cookie
+ * extractor never fires) and no validation pipe.
+ *
+ * Helmet, CORS and Swagger are left out; they do not affect the behaviour
+ * these suites assert.
+ */
+export async function createTestApp(): Promise<{
+  app: INestApplication<App>;
+  moduleFixture: TestingModule;
+}> {
+  const moduleFixture = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication<INestApplication<App>>({
+    rawBody: true,
+  });
+
+  app.use(cookieParser());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  app.useGlobalFilters(new AllExceptionsFilter());
+  app.setGlobalPrefix('api/v1');
+
+  await app.init();
+
+  return { app, moduleFixture };
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,8 +1,11 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
+  "modulePaths": ["<rootDir>/../"],
+  "setupFiles": ["<rootDir>/setup-e2e.ts"],
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
+  "testTimeout": 30000,
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -1,0 +1,31 @@
+import { config } from 'dotenv';
+
+// Runs before the test files are imported.
+//
+// Order matters. dotenv never overwrites a variable that is already present in
+// process.env, so DATABASE_URL is pinned to the test database *before* .env is
+// loaded. That is what keeps e2e runs off the development database: the suites
+// boot the real AppModule, AppService.onModuleInit writes a super admin on
+// startup, and the permission suite creates and deletes users and roles.
+//
+// Without this, the env would only be populated as a side effect of AppModule
+// importing ConfigModule.forRoot(), which is too fragile to rely on.
+config({ path: '.env.test' });
+
+process.env.DATABASE_URL ??=
+  'postgresql://postgres@localhost:5432/aerovex_test?schema=public';
+process.env.NODE_ENV ??= 'test';
+
+config();
+
+const databaseName = /\/([^/?]+)(\?|$)/.exec(
+  process.env.DATABASE_URL ?? '',
+)?.[1];
+
+if (!databaseName?.endsWith('_test')) {
+  throw new Error(
+    `Refusing to run e2e tests against database "${databaseName ?? 'unknown'}". ` +
+      'These suites write to the database. Point DATABASE_URL at a database ' +
+      'whose name ends in _test, either in .env.test or in the environment.',
+  );
+}


### PR DESCRIPTION
The e2e suite had never been run and failed for three reasons, all predating the modular monolith work:

- the spec requested `GET /` expecting `Hello World!`; no such route exists (the app serves `GET /health`)
- `import * as request from 'supertest'` is not callable with `esModuleInterop`
- the jest e2e config had no `modulePaths`, so `src/*` imports could not resolve

The test app also did not apply what `main.ts` applies, so it was not exercising the real thing. `createTestApp` now mirrors the global `api/v1` prefix, cookie-parser, the validation pipe and the exception filter. Without cookie parsing the JWT cookie extractor never fires, which is how login actually delivers tokens.

`auth-permissions.e2e-spec.ts` covers the authorization path against a real request, JWT and database: anonymous is rejected, a permitted user is allowed, a permission-less user is rejected, and a route guarded by authentication alone still lets that user through.

The deny assertion was checked adversarially: granting the role `view/user` flips it from 401 to 200.

`setup-e2e.ts` pins `DATABASE_URL` to a test database before loading `.env` and refuses to run against any database whose name does not end in `_test`, because these suites write.

Verified against local Postgres 16 and Redis: 8 e2e tests pass.

**Merge first** — `chore/ci-and-boundaries` is stacked on this.