### PR TITLE
fix(billing): scope payment and subscription access to the caller

### DIFF
--- a/src/modules/billing/billing.module.spec.ts
+++ b/src/modules/billing/billing.module.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { StripeService } from 'src/external-service/stripe/stripe.service';
@@ -16,11 +17,17 @@ describe('BillingModule', () => {
   let moduleRef: TestingModule;
 
   const prismaMock = {
-    payment: { create: jest.fn() },
+    payment: { create: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn() },
     user: { findUnique: jest.fn(), update: jest.fn() },
   };
 
-  const stripeMock = { createCustomer: jest.fn() };
+  const stripeMock = {
+    createCustomer: jest.fn(),
+    retrievePaymentIntent: jest.fn(),
+    confirmPaymentIntent: jest.fn(),
+    cancelSubscription: jest.fn(),
+    getClient: jest.fn(),
+  };
 
   const userAccountMock = {
     findUserByEmail: jest.fn(),
@@ -178,6 +185,116 @@ describe('BillingModule', () => {
       await expect(
         service.getOrCreateStripeCustomer('missing'),
       ).rejects.toThrow('User with id missing not found');
+    });
+  });
+  describe('ownership scoping', () => {
+    const owner = {
+      id: 'user-1',
+      email: 'owner@example.com',
+      name: 'Owner',
+      stripeCustomerId: 'cus_owner',
+    };
+
+    it('scopes a payment lookup to the caller in the query', async () => {
+      prismaMock.payment.findFirst.mockResolvedValue({ id: 'pay-1' });
+
+      const service = moduleRef.get(BillingService);
+      await service.getPaymentById('pay-1', 'user-1');
+
+      // The userId must be part of the where clause, not checked afterwards.
+      expect(prismaMock.payment.findFirst).toHaveBeenCalledWith({
+        where: { id: 'pay-1', userId: 'user-1' },
+      });
+    });
+
+    it('hides a payment that belongs to somebody else', async () => {
+      // Scoped query returns nothing for a non-owner.
+      prismaMock.payment.findFirst.mockResolvedValue(null);
+
+      const service = moduleRef.get(BillingService);
+      await expect(
+        service.getPaymentById('someone-elses-payment', 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('refuses to confirm a payment intent owned by another customer', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue(owner);
+      stripeMock.retrievePaymentIntent.mockResolvedValue({
+        id: 'pi_victim',
+        customer: 'cus_somebody_else',
+      });
+
+      const service = moduleRef.get(BillingService);
+      await expect(
+        service.confirmPayment('pi_victim', 'pm_1', 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(stripeMock.confirmPaymentIntent).not.toHaveBeenCalled();
+    });
+
+    it('confirms a payment intent the caller owns', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue(owner);
+      stripeMock.retrievePaymentIntent.mockResolvedValue({
+        id: 'pi_mine',
+        customer: 'cus_owner',
+      });
+      stripeMock.confirmPaymentIntent.mockResolvedValue({
+        id: 'pi_mine',
+        status: 'succeeded',
+      });
+
+      const service = moduleRef.get(BillingService);
+      await expect(
+        service.confirmPayment('pi_mine', 'pm_1', 'user-1'),
+      ).resolves.toEqual({ status: 'succeeded', paymentIntentId: 'pi_mine' });
+    });
+
+    it('refuses to cancel a subscription owned by another customer', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue(owner);
+      stripeMock.getClient.mockReturnValue({
+        subscriptions: {
+          retrieve: jest
+            .fn()
+            .mockResolvedValue({ id: 'sub_victim', customer: 'cus_other' }),
+        },
+      });
+
+      const service = moduleRef.get(BillingService);
+      await expect(
+        service.cancelSubscription('sub_victim', 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(stripeMock.cancelSubscription).not.toHaveBeenCalled();
+    });
+
+    it('cancels a subscription the caller owns', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue(owner);
+      stripeMock.getClient.mockReturnValue({
+        subscriptions: {
+          retrieve: jest
+            .fn()
+            .mockResolvedValue({ id: 'sub_mine', customer: 'cus_owner' }),
+        },
+      });
+
+      const service = moduleRef.get(BillingService);
+      await service.cancelSubscription('sub_mine', 'user-1');
+
+      expect(stripeMock.cancelSubscription).toHaveBeenCalledWith('sub_mine');
+    });
+
+    it('denies ownership checks for a user with no billing account', async () => {
+      userAccountMock.findBillingProfileById.mockResolvedValue({
+        ...owner,
+        stripeCustomerId: null,
+      });
+
+      const service = moduleRef.get(BillingService);
+      await expect(
+        service.confirmPayment('pi_x', 'pm_1', 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+      // Verification must not create a customer as a side effect.
+      expect(stripeMock.createCustomer).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/billing/controllers/billing.controller.ts
+++ b/src/modules/billing/controllers/billing.controller.ts
@@ -55,11 +55,16 @@ export class BillingController {
     description: 'Payment confirmed',
   })
   async confirmPayment(
+    @CurrentUser() user: JwtUser | undefined,
     @Body() payload: ConfirmPaymentDto,
   ): Promise<{ success: boolean; message: string; data: object }> {
+    if (!user) {
+      throw new UnauthorizedException('User not authenticated');
+    }
     const result = await this.billingService.confirmPayment(
       payload.paymentIntentId,
       payload.paymentMethodId,
+      user.id,
     );
     return {
       success: true,
@@ -97,9 +102,13 @@ export class BillingController {
     description: 'Payment retrieved successfully',
   })
   async getPaymentById(
+    @CurrentUser() user: JwtUser | undefined,
     @Param('id') id: string,
   ): Promise<{ success: boolean; message: string; data: object }> {
-    const payment = await this.billingService.getPaymentById(id);
+    if (!user) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+    const payment = await this.billingService.getPaymentById(id, user.id);
     return {
       success: true,
       message: 'Payment retrieved successfully',
@@ -140,9 +149,13 @@ export class BillingController {
     description: 'Subscription cancelled successfully',
   })
   async cancelSubscription(
+    @CurrentUser() user: JwtUser | undefined,
     @Param('id') id: string,
   ): Promise<{ success: boolean; message: string }> {
-    await this.billingService.cancelSubscription(id);
+    if (!user) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+    await this.billingService.cancelSubscription(id, user.id);
     return {
       success: true,
       message: 'Subscription cancelled successfully',

--- a/src/modules/billing/repositories/billing.repository.ts
+++ b/src/modules/billing/repositories/billing.repository.ts
@@ -38,6 +38,22 @@ export class BillingRepository {
     });
   }
 
+  /**
+   * A payment, but only if it belongs to the given user.
+   *
+   * Scoping in the query rather than fetching by id and comparing afterwards
+   * means a caller cannot accidentally leak another user's payment by
+   * forgetting the check.
+   */
+  async findPaymentByIdForUser(
+    id: string,
+    userId: string,
+  ): Promise<Payment | null> {
+    return this.prismaService.payment.findFirst({
+      where: { id, userId },
+    });
+  }
+
   async findPaymentByStripePaymentIntentId(
     stripePaymentIntentId: string,
   ): Promise<Payment | null> {

--- a/src/modules/billing/services/billing.service.ts
+++ b/src/modules/billing/services/billing.service.ts
@@ -98,7 +98,18 @@ export class BillingService implements PaymentRecorderContract {
   async confirmPayment(
     paymentIntentId: string,
     paymentMethodId: string,
+    userId: string,
   ): Promise<PaymentConfirmResponse> {
+    const stripeCustomerId = await this.requireStripeCustomerId(userId);
+    const existing =
+      await this.stripeService.retrievePaymentIntent(paymentIntentId);
+
+    if (customerIdOf(existing.customer) !== stripeCustomerId) {
+      throw new NotFoundException(
+        `Payment intent with id ${paymentIntentId} not found`,
+      );
+    }
+
     const paymentIntent = await this.stripeService.confirmPaymentIntent(
       paymentIntentId,
       paymentMethodId,
@@ -132,9 +143,14 @@ export class BillingService implements PaymentRecorderContract {
     return this.billingRepository.findPaymentsByUserId(userId);
   }
 
-  async getPaymentById(paymentId: string): Promise<Payment> {
-    const payment = await this.billingRepository.findPaymentById(paymentId);
+  async getPaymentById(paymentId: string, userId: string): Promise<Payment> {
+    const payment = await this.billingRepository.findPaymentByIdForUser(
+      paymentId,
+      userId,
+    );
 
+    // Not found rather than forbidden on purpose: a distinct 403 would confirm
+    // that someone else's payment exists under this id.
     if (!payment) {
       throw new NotFoundException(`Payment with id ${paymentId} not found`);
     }
@@ -173,8 +189,39 @@ export class BillingService implements PaymentRecorderContract {
     };
   }
 
-  async cancelSubscription(subscriptionId: string): Promise<void> {
+  async cancelSubscription(
+    subscriptionId: string,
+    userId: string,
+  ): Promise<void> {
+    const stripeCustomerId = await this.requireStripeCustomerId(userId);
+    const subscription = await this.stripeService
+      .getClient()
+      .subscriptions.retrieve(subscriptionId);
+
+    if (customerIdOf(subscription.customer) !== stripeCustomerId) {
+      throw new NotFoundException(
+        `Subscription with id ${subscriptionId} not found`,
+      );
+    }
+
     await this.stripeService.cancelSubscription(subscriptionId);
+  }
+
+  /**
+   * The caller's Stripe customer id, for ownership checks.
+   *
+   * Unlike getOrCreateStripeCustomer this never creates one: a user with no
+   * customer id cannot own any intent or subscription, and a verification path
+   * should not have side effects.
+   */
+  private async requireStripeCustomerId(userId: string): Promise<string> {
+    const profile = await this.userAccount.findBillingProfileById(userId);
+
+    if (!profile?.stripeCustomerId) {
+      throw new NotFoundException('No billing account for this user');
+    }
+
+    return profile.stripeCustomerId;
   }
 
   async getUserSubscriptions(userId: string): Promise<Stripe.Subscription[]> {
@@ -225,4 +272,15 @@ export class BillingService implements PaymentRecorderContract {
       clientSecret: setupIntent.client_secret || '',
     };
   }
+}
+
+/**
+ * Stripe returns the customer either as an id or as an expanded object, and as
+ * null when the resource has no customer.
+ */
+function customerIdOf(
+  customer: string | { id: string } | null | undefined,
+): string | null {
+  if (!customer) return null;
+  return typeof customer === 'string' ? customer : customer.id;
 }


### PR DESCRIPTION
Three authenticated routes took an id and acted on it without checking ownership:

- `GET /billing/payments/:id` returned any payment to any logged-in user
- `POST /billing/one-time/confirm` confirmed any payment intent
- `DELETE /billing/subscription/:id` cancelled any subscription

All three now take the current user and verify ownership.

`getPaymentById` uses a repository method that puts `userId` in the `where` clause rather than fetching by id and comparing afterwards, so a caller cannot leak another user's payment by forgetting the check.

`confirmPayment` and `cancelSubscription` retrieve the resource from Stripe and compare its customer against the caller's `stripeCustomerId`, via `requireStripeCustomerId`. That deliberately does not reuse `getOrCreateStripeCustomer`: a verification path must not create a Stripe customer as a side effect.

Failures raise `NotFoundException` rather than `Forbidden`, since a distinct 403 would confirm a resource exists under that id.

Seven tests cover the scoping. Verified adversarially: removing the ownership checks fails three of them.