### PR TITLE
fix(billing): make webhook payment recording idempotent

### DIFF
--- a/prisma/migrations/20260807000000_add_stripe_invoice_id/migration.sql
+++ b/prisma/migrations/20260807000000_add_stripe_invoice_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "payments" ADD COLUMN     "stripe_invoice_id" VARCHAR(255);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "payments_stripe_invoice_id_key" ON "payments"("stripe_invoice_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@ model Payment {
   id                    String      @id @default(uuid()) @db.Uuid()
   userId                String      @map("user_id") @db.Uuid()
   stripePaymentIntentId String?     @unique @map("stripe_payment_intent_id") @db.VarChar(255)
+  stripeInvoiceId       String?     @unique @map("stripe_invoice_id") @db.VarChar(255)
   stripeSubscriptionId  String?     @map("stripe_subscription_id") @db.VarChar(255)
   stripePriceId         String?     @map("stripe_price_id") @db.VarChar(255)
   amount                Int

--- a/src/modules/billing/billing.module.spec.ts
+++ b/src/modules/billing/billing.module.spec.ts
@@ -1,4 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { StripeService } from 'src/external-service/stripe/stripe.service';
@@ -295,6 +296,137 @@ describe('BillingModule', () => {
       ).rejects.toThrow(NotFoundException);
       // Verification must not create a customer as a side effect.
       expect(stripeMock.createCustomer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('webhook idempotency', () => {
+    const stored = { id: 'pay-existing' };
+
+    it('returns the stored payment instead of inserting a duplicate', async () => {
+      // Stripe redelivers a webhook until it gets a 2xx.
+      prismaMock.payment.findUnique.mockResolvedValue(stored);
+
+      const recorder = moduleRef.get<PaymentRecorderContract>(PAYMENT_RECORDER);
+      await expect(
+        recorder.saveSuccessfulPayment(
+          'user-1',
+          'pi_1',
+          100,
+          'usd',
+          'ONE_TIME',
+        ),
+      ).resolves.toBe(stored);
+
+      expect(prismaMock.payment.create).not.toHaveBeenCalled();
+    });
+
+    it('inserts on first delivery', async () => {
+      prismaMock.payment.findUnique.mockResolvedValue(null);
+      prismaMock.payment.create.mockResolvedValue({ id: 'pay-new' });
+
+      const recorder = moduleRef.get<PaymentRecorderContract>(PAYMENT_RECORDER);
+      await recorder.saveSuccessfulPayment(
+        'user-1',
+        'pi_1',
+        100,
+        'usd',
+        'ONE_TIME',
+      );
+
+      expect(prismaMock.payment.create).toHaveBeenCalled();
+    });
+
+    it('survives a concurrent duplicate insert', async () => {
+      // Two redeliveries handled at once both pass the pre-check; Postgres
+      // rejects the loser with P2002, which must not surface as a 500.
+      prismaMock.payment.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(stored);
+      prismaMock.payment.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('duplicate', {
+          code: 'P2002',
+          clientVersion: 'test',
+        }),
+      );
+
+      const recorder = moduleRef.get<PaymentRecorderContract>(PAYMENT_RECORDER);
+      await expect(
+        recorder.saveSuccessfulPayment(
+          'user-1',
+          'pi_1',
+          100,
+          'usd',
+          'ONE_TIME',
+        ),
+      ).resolves.toBe(stored);
+    });
+
+    it('rethrows database errors that are not duplicates', async () => {
+      prismaMock.payment.findUnique.mockResolvedValue(null);
+      prismaMock.payment.create.mockRejectedValue(new Error('connection lost'));
+
+      const recorder = moduleRef.get<PaymentRecorderContract>(PAYMENT_RECORDER);
+      await expect(
+        recorder.saveSuccessfulPayment(
+          'user-1',
+          'pi_1',
+          100,
+          'usd',
+          'ONE_TIME',
+        ),
+      ).rejects.toThrow('connection lost');
+    });
+
+    it('dedupes subscription payments by invoice id', async () => {
+      prismaMock.payment.findUnique.mockResolvedValue(stored);
+
+      const recorder = moduleRef.get<PaymentRecorderContract>(PAYMENT_RECORDER);
+      await expect(
+        recorder.saveSubscriptionPayment(
+          'user-1',
+          'sub_1',
+          'price_1',
+          500,
+          'usd',
+          'desc',
+          'in_1',
+        ),
+      ).resolves.toBe(stored);
+
+      expect(prismaMock.payment.findUnique).toHaveBeenCalledWith({
+        where: { stripeInvoiceId: 'in_1' },
+      });
+      expect(prismaMock.payment.create).not.toHaveBeenCalled();
+    });
+
+    it('persists the invoice id so later redeliveries can be deduped', async () => {
+      prismaMock.payment.findUnique.mockResolvedValue(null);
+      prismaMock.payment.create.mockResolvedValue({ id: 'pay-new' });
+
+      const recorder = moduleRef.get<PaymentRecorderContract>(PAYMENT_RECORDER);
+      await recorder.saveSubscriptionPayment(
+        'user-1',
+        'sub_1',
+        'price_1',
+        500,
+        'usd',
+        'desc',
+        'in_1',
+      );
+
+      expect(prismaMock.payment.create).toHaveBeenCalledWith({
+        data: {
+          userId: 'user-1',
+          stripePaymentIntentId: undefined,
+          stripeInvoiceId: 'in_1',
+          stripeSubscriptionId: 'sub_1',
+          stripePriceId: 'price_1',
+          amount: 500,
+          currency: 'USD',
+          paymentType: 'RECURRING',
+          description: 'desc',
+        },
+      });
     });
   });
 });

--- a/src/modules/billing/contracts/payment-recorder.contract.ts
+++ b/src/modules/billing/contracts/payment-recorder.contract.ts
@@ -15,6 +15,7 @@ import type { UserBillingProfile } from 'src/modules/user/contracts/user-account
 export const PAYMENT_RECORDER = Symbol('PAYMENT_RECORDER');
 
 export interface PaymentRecorderContract {
+  /** Idempotent: redelivery of the same payment intent returns the stored row. */
   saveSuccessfulPayment(
     userId: string,
     paymentIntentId: string,
@@ -24,6 +25,10 @@ export interface PaymentRecorderContract {
     description?: string,
   ): Promise<Payment>;
 
+  /**
+   * @param invoiceId identifies the individual charge. Supplying it makes the
+   * call idempotent, which matters because Stripe redelivers webhooks.
+   */
   saveSubscriptionPayment(
     userId: string,
     subscriptionId: string,
@@ -31,6 +36,7 @@ export interface PaymentRecorderContract {
     amount: number,
     currency: string,
     description?: string,
+    invoiceId?: string,
   ): Promise<Payment>;
 
   /**

--- a/src/modules/billing/repositories/billing.repository.ts
+++ b/src/modules/billing/repositories/billing.repository.ts
@@ -5,6 +5,7 @@ import { PrismaService } from 'src/prisma/prisma.service';
 export interface CreatePaymentData {
   userId: string;
   stripePaymentIntentId?: string;
+  stripeInvoiceId?: string;
   stripeSubscriptionId?: string;
   stripePriceId?: string;
   amount: number;
@@ -22,6 +23,7 @@ export class BillingRepository {
       data: {
         userId: data.userId,
         stripePaymentIntentId: data.stripePaymentIntentId,
+        stripeInvoiceId: data.stripeInvoiceId,
         stripeSubscriptionId: data.stripeSubscriptionId,
         stripePriceId: data.stripePriceId,
         amount: data.amount,
@@ -59,6 +61,14 @@ export class BillingRepository {
   ): Promise<Payment | null> {
     return this.prismaService.payment.findUnique({
       where: { stripePaymentIntentId },
+    });
+  }
+
+  async findPaymentByStripeInvoiceId(
+    stripeInvoiceId: string,
+  ): Promise<Payment | null> {
+    return this.prismaService.payment.findUnique({
+      where: { stripeInvoiceId },
     });
   }
 

--- a/src/modules/billing/services/billing.service.ts
+++ b/src/modules/billing/services/billing.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import type { Payment, PaymentType } from '@prisma/client';
 import type { PaymentRecorderContract } from '../contracts/payment-recorder.contract';
 import { USER_ACCOUNT } from 'src/modules/user/contracts/user-account.contract';
@@ -7,6 +8,7 @@ import type {
   UserBillingProfile,
 } from 'src/modules/user/contracts/user-account.contract';
 import { BillingRepository } from '../repositories/billing.repository';
+import type { CreatePaymentData } from '../repositories/billing.repository';
 import { StripeService } from 'src/external-service/stripe/stripe.service';
 import { CreatePaymentIntentDto } from '../dtos/create-payment-intent.dto';
 import type Stripe from 'stripe';
@@ -129,14 +131,32 @@ export class BillingService implements PaymentRecorderContract {
     paymentType: PaymentType,
     description?: string,
   ): Promise<Payment> {
-    return this.billingRepository.createPayment({
-      userId,
-      stripePaymentIntentId: paymentIntentId,
-      amount,
-      currency,
-      paymentType,
-      description,
-    });
+    // Stripe redelivers a webhook until it gets a 2xx, so this has to be
+    // idempotent. Without the check the retry violated the unique constraint
+    // on stripePaymentIntentId, returned 500, and Stripe kept retrying.
+    const existing =
+      await this.billingRepository.findPaymentByStripePaymentIntentId(
+        paymentIntentId,
+      );
+
+    if (existing) {
+      return existing;
+    }
+
+    return this.createPaymentIgnoringDuplicates(
+      {
+        userId,
+        stripePaymentIntentId: paymentIntentId,
+        amount,
+        currency,
+        paymentType,
+        description,
+      },
+      () =>
+        this.billingRepository.findPaymentByStripePaymentIntentId(
+          paymentIntentId,
+        ),
+    );
   }
 
   async getPaymentHistory(userId: string): Promise<Payment[]> {
@@ -243,16 +263,64 @@ export class BillingService implements PaymentRecorderContract {
     amount: number,
     currency: string,
     description?: string,
+    invoiceId?: string,
   ): Promise<Payment> {
-    return this.billingRepository.createPayment({
-      userId,
-      stripeSubscriptionId: subscriptionId,
-      stripePriceId: priceId,
-      amount,
-      currency,
-      paymentType: 'RECURRING',
-      description,
-    });
+    // A subscription bills repeatedly, so the subscription id cannot identify
+    // one payment. The invoice id can, and it is what makes redelivery of
+    // invoice.payment_succeeded safe.
+    if (invoiceId) {
+      const existing =
+        await this.billingRepository.findPaymentByStripeInvoiceId(invoiceId);
+
+      if (existing) {
+        return existing;
+      }
+    }
+
+    return this.createPaymentIgnoringDuplicates(
+      {
+        userId,
+        stripeSubscriptionId: subscriptionId,
+        stripePriceId: priceId,
+        stripeInvoiceId: invoiceId,
+        amount,
+        currency,
+        paymentType: 'RECURRING',
+        description,
+      },
+      () =>
+        invoiceId
+          ? this.billingRepository.findPaymentByStripeInvoiceId(invoiceId)
+          : Promise.resolve(null),
+    );
+  }
+
+  /**
+   * Insert a payment, tolerating a concurrent insert of the same one.
+   *
+   * The pre-check above closes the common case, but two redeliveries handled
+   * at the same time can both pass it. Postgres still rejects the second with
+   * a unique violation, so that is treated as "already recorded" and the
+   * winning row is returned rather than surfacing a 500 to Stripe.
+   */
+  private async createPaymentIgnoringDuplicates(
+    data: CreatePaymentData,
+    reload: () => Promise<Payment | null>,
+  ): Promise<Payment> {
+    try {
+      return await this.billingRepository.createPayment(data);
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const existing = await reload();
+        if (existing) {
+          return existing;
+        }
+      }
+      throw error;
+    }
   }
 
   async findUserByStripeCustomerId(

--- a/src/webhooks/stripe/stripe-webhook.controller.ts
+++ b/src/webhooks/stripe/stripe-webhook.controller.ts
@@ -4,9 +4,11 @@ import {
   Controller,
   Headers,
   Inject,
+  Logger,
   Post,
   Req,
 } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { PaymentType } from '@prisma/client';
 import type { Request } from 'express';
@@ -29,8 +31,15 @@ interface InvoiceWithPayment {
 }
 
 @ApiTags('webhooks')
+// The global ThrottlerGuard allows 20 requests a minute. Stripe delivers events
+// in bursts and redelivers anything it cannot deliver, so throttling this route
+// turns a spike into 429s and silently delays payments. The signature check is
+// what protects this endpoint.
+@SkipThrottle()
 @Controller('webhooks/stripe')
 export class StripeWebhookController {
+  private readonly logger = new Logger(StripeWebhookController.name);
+
   constructor(
     private readonly stripeService: StripeService,
     @Inject(PAYMENT_RECORDER)
@@ -79,7 +88,7 @@ export class StripeWebhookController {
         break;
 
       default:
-        console.log(`⚠️ Unhandled event type: ${event.type}`);
+        this.logger.log(`⚠️ Unhandled event type: ${event.type}`);
     }
 
     return { received: true };
@@ -91,7 +100,7 @@ export class StripeWebhookController {
     const { metadata, id, amount, currency } = paymentIntent;
 
     if (!metadata.userId) {
-      console.log('No userId in payment intent metadata, skipping...');
+      this.logger.log('No userId in payment intent metadata, skipping...');
       return;
     }
 
@@ -110,14 +119,14 @@ export class StripeWebhookController {
       metadata.description,
     );
 
-    console.log(
+    this.logger.log(
       `Payment ${id} succeeded and saved for user ${metadata.userId}`,
     );
   }
 
   private handlePaymentIntentFailed(paymentIntent: Stripe.PaymentIntent): void {
     const { metadata, id } = paymentIntent;
-    console.log(
+    this.logger.log(
       `Payment ${id} failed for user ${metadata.userId ?? 'unknown'}`,
     );
   }
@@ -128,7 +137,7 @@ export class StripeWebhookController {
     const invoiceData = invoice as unknown as InvoiceWithPayment;
 
     if (!invoiceData.subscription || !invoiceData.customer) {
-      console.log('⚠️ No subscription or customer in invoice, skipping...');
+      this.logger.log('⚠️ No subscription or customer in invoice, skipping...');
       return;
     }
 
@@ -146,7 +155,7 @@ export class StripeWebhookController {
       await this.billingService.findUserByStripeCustomerId(customerId);
 
     if (!user) {
-      console.log(
+      this.logger.log(
         `❌ No user found for Stripe customer ${customerId}, skipping...`,
       );
       return;
@@ -164,6 +173,7 @@ export class StripeWebhookController {
       invoiceData.amount_paid,
       invoiceData.currency,
       `Subscription payment for ${subscriptionId}`,
+      invoice.id,
     );
   }
 }


### PR DESCRIPTION
> Stacked on #28 — base is `fix/billing-ownership`. Merge that first; this retargets to `main` automatically.

Stripe redelivers a webhook until it gets a 2xx. Recording a payment did no duplicate check, so a redelivery violated the unique constraint on `stripe_payment_intent_id`, raised P2002 and returned 500 — after which Stripe kept retrying for days while the payment never recorded. `findPaymentByStripePaymentIntentId` already existed for exactly this and was never called.

Idempotency lives in the billing module rather than the webhook controller, so the contract is safe for any caller.

- `saveSuccessfulPayment` returns the stored row when the intent is already recorded.
- `saveSubscriptionPayment` dedupes on a new `stripeInvoiceId` column. The subscription id cannot serve: a subscription bills repeatedly, so it does not identify one payment. Adds a nullable unique column plus migration; the webhook passes `invoice.id`.
- Both go through `createPaymentIgnoringDuplicates`, which treats a P2002 from a concurrent insert as "already recorded". The pre-check alone leaves a window where two redeliveries both pass it. Other database errors still propagate.

The controller is `@SkipThrottle()`. The global limit of 20 requests a minute, left over from testing, could reject a burst of legitimate Stripe events with 429 and silently delay payments. Signature verification is what protects this route.

`console.log` is replaced with a `Logger`.

Six tests; removing the idempotency logic fails three of them.

**Note:** the migration was generated with `prisma migrate diff` (`migrate dev` cannot run non-interactively) and applied to the test database only. Production needs `prisma migrate deploy`.