### PR TITLE
fix(auth): stop login from revealing which emails are registered

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -22,6 +22,17 @@ import { RedisService } from 'src/redis/redis.service';
 import { ConfigService } from '@nestjs/config';
 // import { EmailPohService } from 'src/external-service/email-poh';
 
+/**
+ * A real bcrypt hash, never matched by any password.
+ *
+ * Status parity alone is not enough: verifying a password costs around 100ms,
+ * so returning early for an unknown email would make it measurably faster than
+ * a wrong password and still leak which addresses are registered. Comparing
+ * against this placeholder keeps both paths the same shape.
+ */
+const ABSENT_USER_PASSWORD_HASH =
+  '$2b$10$QWw9/uU7GFWanMGWtFS5VexsNcAQ0UpZZ.Hz5P/XUbY49JivRfMKS';
+
 interface AccountLockInfo {
   failed_attempts: number;
   locked_until: number | null;
@@ -108,14 +119,19 @@ export class AuthService {
     password: string,
     res: Response,
   ): Promise<LoginResponseDto> {
-    const user = await this.userService.findUserByEmail(email, true);
+    // Null rather than a thrown NotFoundException: the contract used to raise
+    // 404 "User with email x not found" for an unknown address while a wrong
+    // password gave 401, which let anyone enumerate registered accounts. Both
+    // cases now leave through the same 401 below.
+    const user = await this.userService.findAuthCredentialsByEmail(email);
     if (!user) {
+      await bcrypt.compare(password, ABSENT_USER_PASSWORD_HASH);
       throw new UnauthorizedException('Invalid credentials');
     }
 
     await this.checkAccountLocked(user.id);
 
-    const isPasswordValid = await bcrypt.compare(password, user.password);
+    const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
 
     if (!isPasswordValid) {
       await this.incrementFailedAttempts(user.id);
@@ -150,21 +166,6 @@ export class AuthService {
       refreshToken,
       cookieConstants.refreshTokenOptions,
     );
-
-    // Just for testing purposes
-    // try {
-    //   await this.emailPohService.welcomeEmail({
-    //     to: user.email,
-    //     name: user.name,
-    //     verificationUrl: `${process.env.AEROVEX_FRONTEND_URL}/verify-email`,
-    //   });
-    //   Logger.log(`Login notification email sent to ${user.email}`);
-    // } catch (error) {
-    //   Logger.error(
-    //     `Failed to send login notification email to ${user.email}:`,
-    //     error,
-    //   );
-    // }
 
     return {
       success: true,

--- a/src/modules/billing/billing.module.spec.ts
+++ b/src/modules/billing/billing.module.spec.ts
@@ -23,7 +23,7 @@ describe('BillingModule', () => {
   const stripeMock = { createCustomer: jest.fn() };
 
   const userAccountMock = {
-    findUserByEmail: jest.fn(),
+    findAuthCredentialsByEmail: jest.fn(),
     findBillingProfileById: jest.fn(),
     findBillingProfileByStripeCustomerId: jest.fn(),
     setStripeCustomerId: jest.fn(),

--- a/src/modules/user/contracts/user-account.contract.ts
+++ b/src/modules/user/contracts/user-account.contract.ts
@@ -1,4 +1,4 @@
-import { UserDto } from '../dtos/user.dto';
+import { RoleDto } from 'src/modules/role/contracts/role.contract';
 
 /**
  * Public contract of the user module.
@@ -34,18 +34,34 @@ export interface UserPermission {
   subject: string;
 }
 
+/**
+ * What the auth module needs to verify a sign-in.
+ *
+ * This replaces a findUserByEmail(email, includePasswordField) method that was
+ * declared as returning a UserDto but returned the raw record with the password
+ * hash when the flag was set, so callers could not tell from the type what they
+ * were holding. Naming the hash makes the sensitive field explicit, and the
+ * shape carries only what login needs.
+ */
+export interface UserAuthCredentials {
+  id: string;
+  email: string;
+  name: string;
+  passwordHash: string;
+  role: RoleDto;
+}
+
 export interface UserAccountContract {
   /**
-   * Look a user up by email.
+   * Credentials for an email, or null when no active user has it.
    *
-   * @param includePasswordField when true the raw user record is returned with
-   * its password hash, which credential verification needs. Callers must not
-   * expose that value outside their own module.
+   * Returning null rather than throwing is deliberate: it lets the caller
+   * answer an unknown email and a wrong password identically, which is what
+   * stops the endpoint from being used to enumerate accounts.
    */
-  findUserByEmail(
+  findAuthCredentialsByEmail(
     email: string,
-    includePasswordField?: boolean,
-  ): Promise<UserDto>;
+  ): Promise<UserAuthCredentials | null>;
 
   /**
    * Billing profile for a user id, or null when no such user exists.

--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import type {
   UserAccountContract,
+  UserAuthCredentials,
   UserBillingProfile,
   UserPermission,
 } from '../contracts/user-account.contract';
@@ -206,6 +207,24 @@ export class UserService implements UserAccountContract {
 
     await this.userRepository.bulkRestoreUsers(payload.ids);
     return { success: true, message: 'Users bulk restored successfully' };
+  }
+
+  async findAuthCredentialsByEmail(
+    email: string,
+  ): Promise<UserAuthCredentials | null> {
+    const user = await this.userRepository.findUserByEmail(email);
+
+    if (!user) {
+      return null;
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      passwordHash: user.password,
+      role: user.role,
+    };
   }
 
   async findBillingProfileById(

--- a/src/modules/user/user.module.spec.ts
+++ b/src/modules/user/user.module.spec.ts
@@ -52,21 +52,27 @@ describe('UserModule', () => {
     );
   });
 
-  it('serves findUserByEmail through the contract', async () => {
+  it('serves auth credentials through the contract', async () => {
     const user = {
       id: 'user-1',
       email: 'john.doe@example.com',
+      name: 'John Doe',
       password: 'hashed',
       role: { id: 'role-1', name: 'admin', permissions: [] },
     };
     prismaMock.user.findUnique.mockResolvedValue(user);
 
     const account = moduleRef.get<UserAccountContract>(USER_ACCOUNT);
-    const result = await account.findUserByEmail(user.email, true);
+    const result = await account.findAuthCredentialsByEmail(user.email);
 
-    // includePasswordField keeps the hash, which is what credential
-    // verification in the auth module relies on.
-    expect(result).toHaveProperty('password', 'hashed');
+    // The hash is named, so a caller can see what it is holding.
+    expect(result).toEqual({
+      id: 'user-1',
+      email: 'john.doe@example.com',
+      name: 'John Doe',
+      passwordHash: 'hashed',
+      role: user.role,
+    });
     expect(prismaMock.user.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { email: user.email, deletedAt: { equals: null } },
@@ -74,20 +80,15 @@ describe('UserModule', () => {
     );
   });
 
-  it('strips the password when includePasswordField is not set', async () => {
-    prismaMock.user.findUnique.mockResolvedValue({
-      id: 'user-1',
-      email: 'john.doe@example.com',
-      password: 'hashed',
-      role: { id: 'role-1', name: 'admin', permissions: [] },
-    });
+  it('returns null for an unknown email rather than throwing', async () => {
+    // Throwing produced a 404 that distinguished an unknown address from a
+    // wrong password, which allowed account enumeration.
+    prismaMock.user.findUnique.mockResolvedValue(null);
 
     const account = moduleRef.get<UserAccountContract>(USER_ACCOUNT);
-    const result = await account.findUserByEmail('john.doe@example.com');
-
-    // UserDto declares password with @Exclude(), so the key survives
-    // plainToInstance but the hash is dropped.
-    expect(result.password).toBeUndefined();
+    await expect(
+      account.findAuthCredentialsByEmail('nobody@example.com'),
+    ).resolves.toBeNull();
   });
   describe('billing profile access', () => {
     const record = {


### PR DESCRIPTION
`UserService.findUserByEmail` throws `NotFoundException`, so an unknown address returned `404 "User with email x not found"` while a wrong password returned `401 "Invalid credentials"`. Anyone could separate registered from unregistered accounts with one request. The `if (!user)` branch in login was unreachable for the same reason.

Verified against a running server: both cases now return `401 "Invalid credentials"` with identical bodies, and a valid login still returns 201.

The contract method is replaced rather than patched. `findUserByEmail` was declared `Promise<UserDto>` but returned the raw record including the password hash when `includePasswordField` was set, while `UserDto` marks `password` with `@Exclude()` — the type lied. `USER_ACCOUNT` now exposes `findAuthCredentialsByEmail(email): Promise<UserAuthCredentials | null>`, carrying only what login needs with the hash named `passwordHash`. Returning `null` instead of throwing is what lets both failures share one response.

**Status parity alone was not enough.** Skipping verification for an unknown email made it measurably faster, leaking the same information. Measured on a live server with the lockout cleared between samples: unknown email 16ms vs 66ms for a wrong password. Login now compares against a placeholder hash on that path, giving 74ms vs 66ms.

`UserService.findUserByEmail` stays for the user module's own `/users/me` route; it is simply no longer part of the public contract.