### PR TITLE
fix(auth): revoke refresh tokens and check account standing

### DIFF
--- a/src/modules/auth/controllers/auth.controller.ts
+++ b/src/modules/auth/controllers/auth.controller.ts
@@ -81,7 +81,12 @@ export class AuthController {
     description: 'Logout successful',
     type: LogoutResponseDto,
   })
-  logout(@Res({ passthrough: true }) res: Response): LogoutResponseDto {
-    return this.authService.logout(res);
+  async logout(
+    @Req() req: RequestWithCookies,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<LogoutResponseDto> {
+    // The refresh token identifies the session to revoke, so logout works even
+    // once the access token has expired.
+    return await this.authService.logout(req.cookies.refresh_token, res);
   }
 }

--- a/src/modules/auth/services/auth.service.spec.ts
+++ b/src/modules/auth/services/auth.service.spec.ts
@@ -1,0 +1,159 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import type { Response } from 'express';
+import type { UserAccountContract } from 'src/modules/user/contracts/user-account.contract';
+import { RedisService } from 'src/redis/redis.service';
+import { AuthService } from './auth.service';
+
+/**
+ * Session lifetime behaviour.
+ *
+ * Before this, a refresh token stayed valid for its full fifteen days no
+ * matter what: logout only cleared the cookie, the same token was reusable
+ * forever, and nothing rechecked whether the account still existed or was
+ * still allowed to sign in.
+ */
+describe('AuthService sessions', () => {
+  let service: AuthService;
+  let redis: Map<string, unknown>;
+  let userAccount: {
+    findAuthCredentialsByEmail: jest.Mock;
+    findAccountStandingById: jest.Mock;
+  };
+
+  const config = new ConfigService({
+    JWT_ACCESS_SECRET_KEY: 'test-access-secret',
+    JWT_REFRESH_SECRET_KEY: 'test-refresh-secret',
+  });
+  const jwtService = new JwtService();
+
+  const res = () => ({
+    cookie: jest.fn<void, [string, string, object]>(),
+    clearCookie: jest.fn<void, [string]>(),
+  });
+
+  const activeStanding = {
+    id: 'user-1',
+    isActive: true,
+    accountStatus: 'ACTIVE' as const,
+    deletedAt: null,
+  };
+
+  const signRefresh = (payload: object) =>
+    jwtService.sign(payload, {
+      secret: 'test-refresh-secret',
+      expiresIn: '15d',
+    });
+
+  beforeEach(() => {
+    redis = new Map();
+    userAccount = {
+      findAuthCredentialsByEmail: jest.fn(),
+      findAccountStandingById: jest.fn().mockResolvedValue(activeStanding),
+    };
+
+    const redisService = {
+      get: jest.fn((key: string) => Promise.resolve(redis.get(key) ?? null)),
+      set: jest.fn((key: string, value: unknown) => {
+        redis.set(key, value);
+        return Promise.resolve();
+      }),
+      del: jest.fn((key: string) => {
+        redis.delete(key);
+        return Promise.resolve(1);
+      }),
+    };
+
+    service = new AuthService(
+      userAccount as unknown as UserAccountContract,
+      jwtService,
+      redisService as unknown as RedisService,
+      config,
+    );
+  });
+
+  describe('refresh', () => {
+    it('rotates the refresh token instead of reusing it', async () => {
+      const response = res();
+      await service.refresh(
+        signRefresh({ id: 'user-1', email: 'a@b.c', tokenVersion: 0 }),
+        response as unknown as Response,
+      );
+
+      const cookieNames = response.cookie.mock.calls.map((call) => call[0]);
+      expect(cookieNames).toContain('access_token');
+      expect(cookieNames).toContain('refresh_token');
+    });
+
+    it('rejects a refresh token issued before logout', async () => {
+      const token = signRefresh({
+        id: 'user-1',
+        email: 'a@b.c',
+        tokenVersion: 0,
+      });
+
+      await service.logout(token, res() as unknown as Response);
+
+      // Same token, replayed after logout.
+      await expect(
+        service.refresh(token, res() as unknown as Response),
+      ).rejects.toThrow(new UnauthorizedException('Invalid refresh token'));
+    });
+
+    it('rejects a token whose version does not match', async () => {
+      await expect(
+        service.refresh(
+          signRefresh({ id: 'user-1', email: 'a@b.c', tokenVersion: 7 }),
+          res() as unknown as Response,
+        ),
+      ).rejects.toThrow(new UnauthorizedException('Invalid refresh token'));
+    });
+
+    it.each([
+      ['suspended', { ...activeStanding, accountStatus: 'SUSPENDED' as const }],
+      ['deactivated', { ...activeStanding, isActive: false }],
+      ['soft deleted', { ...activeStanding, deletedAt: new Date() }],
+      ['deleted outright', null],
+    ])('refuses to refresh a %s account', async (_label, standing) => {
+      userAccount.findAccountStandingById.mockResolvedValue(standing);
+
+      await expect(
+        service.refresh(
+          signRefresh({ id: 'user-1', email: 'a@b.c', tokenVersion: 0 }),
+          res() as unknown as Response,
+        ),
+      ).rejects.toThrow(new UnauthorizedException('Account is not active'));
+    });
+
+    it('rejects a token signed with the wrong secret', async () => {
+      const forged = jwtService.sign(
+        { id: 'user-1', email: 'a@b.c', tokenVersion: 0 },
+        { secret: 'not-the-refresh-secret', expiresIn: '15d' },
+      );
+
+      await expect(
+        service.refresh(forged, res() as unknown as Response),
+      ).rejects.toThrow(new UnauthorizedException('Invalid refresh token'));
+    });
+  });
+
+  describe('logout', () => {
+    it('clears both cookies', async () => {
+      const response = res();
+      await service.logout(undefined, response as unknown as Response);
+
+      const cleared = response.clearCookie.mock.calls.map((call) => call[0]);
+      expect(cleared).toEqual(['access_token', 'refresh_token']);
+    });
+
+    it('still clears cookies when the token cannot be read', async () => {
+      const response = res();
+      await expect(
+        service.logout('not-a-jwt', response as unknown as Response),
+      ).resolves.toEqual({ success: true, message: 'Logout successful' });
+
+      expect(response.clearCookie).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -7,6 +7,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { USER_ACCOUNT } from 'src/modules/user/contracts/user-account.contract';
+import type { UserAccountStanding } from 'src/modules/user/contracts/user-account.contract';
 import type { UserAccountContract } from 'src/modules/user/contracts/user-account.contract';
 import { LoginResponseDto } from '../dtos/login-response.dto';
 import * as bcrypt from 'bcrypt';
@@ -32,6 +33,18 @@ import { ConfigService } from '@nestjs/config';
  */
 const ABSENT_USER_PASSWORD_HASH =
   '$2b$10$QWw9/uU7GFWanMGWtFS5VexsNcAQ0UpZZ.Hz5P/XUbY49JivRfMKS';
+
+/**
+ * Refresh tokens carry the version their session was issued at.
+ *
+ * A refresh token used to stay valid for its full fifteen days no matter what:
+ * logging out only cleared the cookie, so a copied token kept working, and
+ * nothing rechecked the account. Bumping the stored version invalidates every
+ * refresh token issued for that user.
+ */
+interface RefreshTokenPayload extends JwtUser {
+  tokenVersion?: number;
+}
 
 interface AccountLockInfo {
   failed_attempts: number;
@@ -138,6 +151,15 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    // Checked after the password so a wrong password on a suspended account
+    // still looks like a wrong password.
+    this.assertAccountUsable({
+      id: user.id,
+      isActive: user.isActive,
+      accountStatus: user.accountStatus,
+      deletedAt: null,
+    });
+
     await this.resetFailedAttempts(user.id);
 
     const payload = {
@@ -150,10 +172,14 @@ export class AuthService {
       expiresIn: jwtConfig.accessExpiresIn(this.configService),
     });
 
-    const refreshToken = await this.jwtService.signAsync(payload, {
-      secret: jwtConfig.refreshSecret(this.configService),
-      expiresIn: jwtConfig.refreshExpiresIn(this.configService),
-    });
+    // Stamped with the current version so a later logout can invalidate it.
+    const refreshToken = await this.jwtService.signAsync(
+      { ...payload, tokenVersion: await this.getTokenVersion(user.id) },
+      {
+        secret: jwtConfig.refreshSecret(this.configService),
+        expiresIn: jwtConfig.refreshExpiresIn(this.configService),
+      },
+    );
 
     res.cookie(
       cookieConstants.accessTokenName,
@@ -179,40 +205,121 @@ export class AuthService {
     };
   }
 
+  private getTokenVersionKey(userId: string): string {
+    return `auth:token_version:${userId}`;
+  }
+
+  private async getTokenVersion(userId: string): Promise<number> {
+    const stored = await this.redisService.get<number>(
+      this.getTokenVersionKey(userId),
+    );
+    return stored ?? 0;
+  }
+
+  /** Invalidates every refresh token already issued for this user. */
+  private async bumpTokenVersion(userId: string): Promise<void> {
+    const next = (await this.getTokenVersion(userId)) + 1;
+    await this.redisService.set(this.getTokenVersionKey(userId), next);
+  }
+
+  private assertAccountUsable(standing: UserAccountStanding | null): void {
+    // One message for every case: which of them applies is not something an
+    // unauthenticated caller should be able to learn.
+    if (
+      !standing ||
+      standing.deletedAt !== null ||
+      !standing.isActive ||
+      standing.accountStatus !== 'ACTIVE'
+    ) {
+      throw new UnauthorizedException('Account is not active');
+    }
+  }
+
   async refresh(
     refreshToken: string,
     res: Response,
   ): Promise<RefreshResponseDto> {
+    let payload: RefreshTokenPayload;
+
     try {
-      const payload = await this.jwtService.verifyAsync<JwtUser>(refreshToken, {
-        secret: jwtConfig.refreshSecret(this.configService),
-      });
-
-      const newAccessToken = await this.jwtService.signAsync(
-        { id: payload.id, email: payload.email },
-        {
-          secret: jwtConfig.accessSecret(this.configService),
-          expiresIn: jwtConfig.accessExpiresIn(this.configService),
-        },
+      payload = await this.jwtService.verifyAsync<RefreshTokenPayload>(
+        refreshToken,
+        { secret: jwtConfig.refreshSecret(this.configService) },
       );
-
-      res.cookie(
-        cookieConstants.accessTokenName,
-        newAccessToken,
-        cookieConstants.accessTokenOptions,
-      );
-
-      return {
-        success: true,
-        message: 'Token refreshed successfully',
-      };
-    } catch (error: any) {
+    } catch (error) {
       Logger.error('Refresh token validation error:', error);
       throw new UnauthorizedException('Invalid refresh token');
     }
+
+    // Revocation. A token issued before the last logout, or before any other
+    // event that bumped the version, no longer matches.
+    const currentVersion = await this.getTokenVersion(payload.id);
+    if ((payload.tokenVersion ?? 0) !== currentVersion) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    // The account may have been suspended, deactivated or deleted since the
+    // token was issued. Nothing checked this before.
+    this.assertAccountUsable(
+      await this.userService.findAccountStandingById(payload.id),
+    );
+
+    const newAccessToken = await this.jwtService.signAsync(
+      { id: payload.id, email: payload.email },
+      {
+        secret: jwtConfig.accessSecret(this.configService),
+        expiresIn: jwtConfig.accessExpiresIn(this.configService),
+      },
+    );
+
+    // Rotate. Reusing the same refresh token for fifteen days gives an
+    // attacker who captures it the same lifetime as the legitimate session.
+    const newRefreshToken = await this.jwtService.signAsync(
+      { id: payload.id, email: payload.email, tokenVersion: currentVersion },
+      {
+        secret: jwtConfig.refreshSecret(this.configService),
+        expiresIn: jwtConfig.refreshExpiresIn(this.configService),
+      },
+    );
+
+    res.cookie(
+      cookieConstants.accessTokenName,
+      newAccessToken,
+      cookieConstants.accessTokenOptions,
+    );
+    res.cookie(
+      cookieConstants.refreshTokenName,
+      newRefreshToken,
+      cookieConstants.refreshTokenOptions,
+    );
+
+    return {
+      success: true,
+      message: 'Token refreshed successfully',
+    };
   }
 
-  logout(res: Response): LogoutResponseDto {
+  async logout(
+    refreshToken: string | undefined,
+    res: Response,
+  ): Promise<LogoutResponseDto> {
+    // Clearing the cookie only stopped this browser from sending the token.
+    // Bumping the version makes any copy of it useless. The refresh token
+    // identifies the user, so logging out works even with an expired access
+    // token.
+    if (refreshToken) {
+      try {
+        const payload = await this.jwtService.verifyAsync<RefreshTokenPayload>(
+          refreshToken,
+          { secret: jwtConfig.refreshSecret(this.configService) },
+        );
+        await this.bumpTokenVersion(payload.id);
+      } catch {
+        // An unreadable token means there is no session to revoke; clearing
+        // the cookies below is still the right response.
+      }
+    }
+
     res.clearCookie('access_token');
     res.clearCookie('refresh_token');
 

--- a/src/modules/billing/billing.module.spec.ts
+++ b/src/modules/billing/billing.module.spec.ts
@@ -24,6 +24,7 @@ describe('BillingModule', () => {
 
   const userAccountMock = {
     findAuthCredentialsByEmail: jest.fn(),
+    findAccountStandingById: jest.fn(),
     findBillingProfileById: jest.fn(),
     findBillingProfileByStripeCustomerId: jest.fn(),
     setStripeCustomerId: jest.fn(),

--- a/src/modules/user/contracts/user-account.contract.ts
+++ b/src/modules/user/contracts/user-account.contract.ts
@@ -1,4 +1,7 @@
 import { RoleDto } from 'src/modules/role/contracts/role.contract';
+import type { AccountStatus } from '../enums/enum';
+
+export type { AccountStatus };
 
 /**
  * Public contract of the user module.
@@ -49,6 +52,22 @@ export interface UserAuthCredentials {
   name: string;
   passwordHash: string;
   role: RoleDto;
+  isActive: boolean;
+  accountStatus: AccountStatus;
+}
+
+/**
+ * Whether an account may still be used.
+ *
+ * accountStatus, isActive and deletedAt exist on the user table but were never
+ * consulted anywhere in auth, so a suspended, deactivated or soft-deleted user
+ * could sign in and keep refreshing indefinitely.
+ */
+export interface UserAccountStanding {
+  id: string;
+  isActive: boolean;
+  accountStatus: AccountStatus;
+  deletedAt: Date | null;
 }
 
 export interface UserAccountContract {
@@ -86,4 +105,12 @@ export interface UserAccountContract {
    * from a user that exists with no permissions.
    */
   findPermissionsByUserId(userId: string): Promise<UserPermission[] | null>;
+
+  /**
+   * Standing for a user id, or null when no such user exists.
+   *
+   * Deliberately unfiltered by deletedAt so the caller can tell a deleted
+   * account apart from one that never existed.
+   */
+  findAccountStandingById(userId: string): Promise<UserAccountStanding | null>;
 }

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -230,6 +230,18 @@ export class UserRepository {
     });
   }
 
+  async findAccountStandingById(userId: string) {
+    return this.prismaService.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        isActive: true,
+        accountStatus: true,
+        deletedAt: true,
+      },
+    });
+  }
+
   async findSoftDeletedUsersByIds(
     ids: string[],
   ): Promise<UserWithRoleAndPermission[]> {

--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import type {
   UserAccountContract,
+  UserAccountStanding,
   UserAuthCredentials,
   UserBillingProfile,
   UserPermission,
@@ -224,7 +225,15 @@ export class UserService implements UserAccountContract {
       name: user.name,
       passwordHash: user.password,
       role: user.role,
+      isActive: user.isActive,
+      accountStatus: user.accountStatus,
     };
+  }
+
+  async findAccountStandingById(
+    userId: string,
+  ): Promise<UserAccountStanding | null> {
+    return this.userRepository.findAccountStandingById(userId);
   }
 
   async findBillingProfileById(

--- a/src/modules/user/user.module.spec.ts
+++ b/src/modules/user/user.module.spec.ts
@@ -59,6 +59,8 @@ describe('UserModule', () => {
       name: 'John Doe',
       password: 'hashed',
       role: { id: 'role-1', name: 'admin', permissions: [] },
+      isActive: true,
+      accountStatus: 'ACTIVE',
     };
     prismaMock.user.findUnique.mockResolvedValue(user);
 
@@ -72,6 +74,8 @@ describe('UserModule', () => {
       name: 'John Doe',
       passwordHash: 'hashed',
       role: user.role,
+      isActive: true,
+      accountStatus: 'ACTIVE',
     });
     expect(prismaMock.user.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
> Stacked on #30 — base is `fix/login-credentials-contract`. Merge that first; this retargets to `main` automatically.

A refresh token stayed usable for its full fifteen days regardless of what happened to the session or the account. Logout only cleared the cookie, so a copied token kept working. Refresh never rechecked the user, and `accountStatus`, `isActive` and `deletedAt` existed on the table but were read nowhere in auth — a suspended, deactivated or soft-deleted user could keep minting access tokens indefinitely.

**Revocation.** Refresh tokens carry the token version their session was issued at, stored per user in Redis. Logout bumps that version, invalidating every refresh token already issued for that user rather than just the copy in the caller's browser. Logout reads the refresh token rather than requiring a valid access token, so it still works once the access token has expired; an unreadable token still clears cookies.

**Rotation.** Refresh now issues a new refresh token as well as a new access token. Reusing one token for fifteen days gives anyone who captures it the same lifetime as the real session.

**Account standing.** `USER_ACCOUNT` gains `findAccountStandingById`, and `UserAuthCredentials` carries `isActive` and `accountStatus`. Login checks standing *after* verifying the password, so a wrong password on a suspended account still looks like a wrong password. Refresh checks it on every call. Every rejected case raises the same `Account is not active`, since which one applies is not something an unauthenticated caller should learn.

Ten tests cover rotation, replay after logout, a mismatched version, a token signed with the wrong secret, and refusal for suspended, deactivated, soft-deleted and missing accounts. Verified adversarially: removing the revocation and standing checks fails six of them.

**Known limitation:** access tokens are not checked against standing, only refresh is. `JwtStrategy` would have to hit the database on every request to close that. Access tokens last five minutes, so a suspension takes effect within that window.